### PR TITLE
Fixing NaNs during sensitivies and raise warning when dg/dz=0

### DIFF
--- a/examples/green_book/README.paresto
+++ b/examples/green_book/README.paresto
@@ -218,3 +218,19 @@ parameters are commone to all experiments.
 may be passed into the user's DAE functions by anonymous funtions as in standard
 octave/matlab.  There is no need to supply special paresto options for passing
 constants.
+
+15. Titus made changes to DAE solver to return both the state and algebraic variables.
+Previously, the DAE solver only returned the state variables,
+and the algebraic variables were calculated from the state variables.
+This led to also changing the collocation points to include the end point,
+i.e. Radau collocation. 
+
+16. For unknown reasons, fix #15 led to initial algebraic variables lagrange multipliers
+to be a small nonzero number, rather than zero.
+This is fixed by setting sol.lam_x for indices other that thetaind to be zero.
+
+17. Added lines to check if dg/dz is nonsingular, i.e., checks if formulation 
+is a high-index DAE. Such as examples/simplerxn_implicit.m
+
+18. Set sol.lam_x(thetaind) to be nonzero. fix bug when parameters or initial conditions did not appear in the objective, 
+  confidence intervals for other parameters were affected.

--- a/paresto.m
+++ b/paresto.m
@@ -695,9 +695,14 @@ classdef paresto < handle
 	sol.lam_g = casadi.DM(sol.lam_g);
 
   sol.lam_x = full(sol.lam_x);
-  %% Ensure lam_x(~self.thetaind) is exactly zero, i.e., don't constrain free parameters
+  %% Ensure lam_x(~self.thetaind) is exactly zero, 
+  %% i.e., don't constrain variables to be solved for
+  %% such as z0
   sol.lam_x(abs(sol.lam_x)<1e-13) = 0;
-  %% Ensure lam_x(self.thetaind) is not exactly zero
+  %% Ensure lam_x(self.thetaind) is not exactly zero,
+  %% i.e., enforce equality constraints 
+  %% on estimated parameters and initial conditions
+  %% even if they don't appear in objective function
   sol.lam_x(sol.lam_x(self.thetaind)==0) = 1e-300;
   sol.lam_x = casadi.DM(sol.lam_x);
 

--- a/paresto.m
+++ b/paresto.m
@@ -190,14 +190,17 @@ classdef paresto < handle
       % DAE
       ode = self.fun2sym('ode', t, yy, pp);
       alg = self.fun2sym('alg', t, yy, pp);
-
+      disp(alg.size(1)>0)
       % Check dg/dz
-      dalgdz = jacobian(alg, z);
-      determinant_dalgdz = det(dalgdz);
-      if is_zero(determinant_dalgdz)
-        warning('The Jacobian of the algebraic equations wrt z is singular. You may have formulated a high index DAE.');
-      endif
-
+      disp(alg.size(1))
+      if alg.size(1)>0
+        dalgdz = jacobian(alg, z);
+        disp(dalgdz)
+        determinant_dalgdz = det(dalgdz);
+        if is_zero(determinant_dalgdz)
+          warning('The Jacobian of the algebraic equations wrt z is singular. You may have formulated a high index DAE.');
+        end
+      end
 
       % Least squares objective
       lsq = self.fun2sym('lsq', t, yy, pp);

--- a/paresto.m
+++ b/paresto.m
@@ -689,6 +689,19 @@ classdef paresto < handle
   sol.lam_x = full(sol.lam_x);
   sol.lam_x(sol.lam_x(self.thetaind)==0) = 1e-300;
   sol.lam_x = casadi.DM(sol.lam_x);
+  
+  disp('sol.x');
+  disp(sol.x);
+  disp('sol.lam_x');
+  disp(sol.lam_x);
+  disp('sol.lam_g');
+  disp(sol.lam_g);
+  disp('sol.lam_p');
+  disp(sol.lam_p);
+  disp('sol.f');
+  disp(sol.f);
+  disp('sol.g');
+  disp(sol.g);
 
 	fsol = self.fsolver('x0', sol.x, 'lam_x0', sol.lam_x, 'lam_g0', sol.lam_g,...
 			    'lbx', lbw, 'ubx', ubw, 'lbg', 0, 'ubg', 0, 'p', d,...

--- a/paresto.m
+++ b/paresto.m
@@ -629,8 +629,14 @@ classdef paresto < handle
       lbw(self.thetaind) = r.thetavec;
       ubw(self.thetaind) = r.thetavec;
 
+      disp('lbw')
+      disp(lbw)
+      disp('ubw')
+      disp(ubw)
+
       sol = self.solver('x0', sol.x, 'lam_x0', sol.lam_x, 'lam_g0', sol.lam_g,...
                    'lbx', lbw, 'ubx', ubw, 'lbg', 0, 'ubg', 0, 'p', d);
+      disp(sol.x(8))
 
       % Optimal cost
       r.f = full(sol.f);
@@ -688,8 +694,11 @@ classdef paresto < handle
   %% Ensure lam_x(self.thetaind) is not exactly zero
   sol.lam_x = full(sol.lam_x);
   sol.lam_x(sol.lam_x(self.thetaind)==0) = 1e-300;
+  sol.lam_x(8) = 0;
   sol.lam_x = casadi.DM(sol.lam_x);
-  
+
+
+  disp(self.thetaind)
   disp('sol.x');
   disp(sol.x);
   disp('sol.lam_x');
@@ -709,6 +718,8 @@ classdef paresto < handle
 			    'out_lam_p', sol.lam_p, 'out_f', sol.f, 'out_g', sol.g,... 
 			    'fwd_lbx', seed, 'fwd_ubx', seed);
         sens = -full(fsol.fwd_lam_x);
+        disp('sens')
+        disp(sens)
         r.d2f_dtheta2 = sens(self.thetaind,:);
 
         % Get forward derivatives w.r.t. theta

--- a/paresto.m
+++ b/paresto.m
@@ -195,7 +195,7 @@ classdef paresto < handle
       dalgdz = jacobian(alg, z);
       determinant_dalgdz = det(dalgdz);
       if is_zero(determinant_dalgdz)
-        error('The Jacobian of the algebraic equations wrt z is singular. You may have formulated a high index DAE.');
+        warning('The Jacobian of the algebraic equations wrt z is singular. You may have formulated a high index DAE.');
       endif
 
 


### PR DESCRIPTION
Fixed issue where lagrange multipliers for initial algebraic states were small numbers (sol.lam_x(z0_ind) != 0).
This led to NaNs in the sensitivities (fix examples/simplerxn_extents.m)

Added a check for dg/dz to check if the problem is high index and if dg/dz is singular, paresto raises a warning, but continues (you can still get parameter values, but not sensitivities)

Added comments to readme.paresto documenting recent changes